### PR TITLE
Add metadata to video preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "icons": "^1.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-helmet-async": "^1.3.0",
         "react-player": "^2.9.0",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
@@ -24094,6 +24095,22 @@
         "react": ">=16"
       }
     },
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -25594,6 +25611,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -47068,6 +47090,18 @@
       "integrity": "sha512-rOFGh3KgC2Ot66DmVCcT1p8lVJCmmCjzGE5WK/KsyDFi43wpIbW1PYcr04cQ3mbF4LaIkY6SpK7k1DOgwtpUXA==",
       "requires": {}
     },
+    "react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -48156,6 +48190,11 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "icons": "^1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-helmet-async": "^1.3.0",
     "react-player": "^2.9.0",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,32 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Klepp it like it's hot" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>Klepp</title>
-  </head>
-
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,18 +14,45 @@ import UploadFile from "./components/UploadFile"
 import KleppVideoPreview from "./components/KleppVideoPreview"
 import { Container } from "@mui/material"
 
+import { Helmet, HelmetProvider } from "react-helmet-async"
+
 Amplify.configure(AMPLIFY_CONFIG)
 
 function App() {
   return (
-    <HashRouter basename={process.env.PUBLIC_URL}>
-      <Routes>
-        <Route path='/' element={<Main />} />
-        <Route path='/login' element={<Login />} />
-        <Route path='/upload' element={<UploadFile />} />
-        <Route path='/video' element={<KleppVideoPreview />} />
-      </Routes>
-    </HashRouter>
+    <HelmetProvider>
+      <Helmet>
+        {/*Defaults*/}
+        <meta charSet='utf-8' />
+        <link rel='icon' href={`${process.env.PUBLIC_URL}/favicon.ico`} />
+        <link rel='manifest' href={`${process.env.PUBLIC_URL}/manifest.json`} />
+        <link
+          rel='stylesheet'
+          href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap'
+        />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <meta name='theme-color' content='#000000' />
+        <meta property='og:description' content="Klepp it like it's hot" />
+        <meta property='og:title' content='Klepp' />
+        <title>Klepp</title>
+
+        {/*Override these*/}
+        {/*<meta property='og:type' content='video' />*/}
+        {/*<meta*/}
+        {/*  property='og:url'*/}
+        {/*  content='https://klepp.me/#/video?uri=https://gg.klepp.me/hotfix/13.mp4'*/}
+        {/*/>*/}
+        {/*<meta property='og:image' content='https://gg.klepp.me/hotfix/13.png' />*/}
+      </Helmet>
+      <HashRouter basename={process.env.PUBLIC_URL}>
+        <Routes>
+          <Route path='/' element={<Main />} />
+          <Route path='/login' element={<Login />} />
+          <Route path='/upload' element={<UploadFile />} />
+          <Route path='/video' element={<KleppVideoPreview />} />
+        </Routes>
+      </HashRouter>
+    </HelmetProvider>
   )
 }
 

--- a/src/components/KleppVideoCard.tsx
+++ b/src/components/KleppVideoCard.tsx
@@ -176,7 +176,7 @@ function KleppVideoCard(props: KleppVideoCardProps) {
   }
 
   async function openVideoClicked() {
-    navigate(`video?uri=${props.file.uri}`)
+    navigate(`video?path=${props.file.path}`)
   }
 
   function renderLike() {

--- a/src/components/KleppVideoPlayer.tsx
+++ b/src/components/KleppVideoPlayer.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import ReactPlayer from "react-player"
+import { Helmet, HelmetProvider } from "react-helmet-async"
 
 interface KleppVideoPlayerItem {
   embedUrl: string

--- a/src/components/KleppVideoPreview.tsx
+++ b/src/components/KleppVideoPreview.tsx
@@ -1,38 +1,58 @@
 import ReactPlayer from "react-player"
 import { useSearchParams } from "react-router-dom"
-import { API_CONFIG } from "../config/api_config"
+import { Helmet } from "react-helmet-async"
+import React, { useEffect, useState } from "react"
+import kleppVideoService from "../services/kleppvideoservice"
+import { KleppVideoFile } from "../models/KleppVideoModels"
 
 function KleppVideoPlayer() {
   const [searchParams] = useSearchParams()
+  const [video, setVideo] = useState<KleppVideoFile | null>(null)
 
-  function getValidUri() {
-    if (
-      `${searchParams.get("uri")}` != null &&
-      `${searchParams.get("uri")}`.startsWith(`${API_CONFIG.fileBaseUrl}`)
-    ) {
-      return `${searchParams.get("uri")}`
-    } else {
-      throw new Error("Unsupported uri path")
+  useEffect(() => {
+    getVideo()
+  }, [searchParams])
+
+  function getVideo() {
+    if (`${searchParams.get("path")}` != null) {
+      kleppVideoService
+        .getFiles(`?path=${searchParams.get("path")}`)
+        .then(res => {
+          if (res.data.response) {
+            setVideo(res.data.response[0])
+          } else {
+            setVideo(null)
+          }
+        })
     }
   }
 
   return (
-    <div className='klepp-videopreview-container'>
-      <ReactPlayer
-        className='klepp-videoplayer'
-        width='100%'
-        height='100%'
-        url={getValidUri()}
-        light={false}
-        config={{
-          file: {
-            forceVideo: true,
-            attributes: {
-              controls: true,
+    <div>
+      <Helmet>
+        <meta property='og:title' content='Klepp' />
+        <meta property='og:type' content='video' />
+        <meta property='og:url' content={video?.uri} />
+        <meta property='og:image' content={video?.thumbnail_uri} />
+      </Helmet>
+
+      <div className='klepp-videopreview-container'>
+        <ReactPlayer
+          className='klepp-videoplayer'
+          width='100%'
+          height='100%'
+          url={video?.uri}
+          light={false}
+          config={{
+            file: {
+              forceVideo: true,
+              attributes: {
+                controls: true,
+              },
             },
-          },
-        }}
-      />
+          }}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
*This branch is branched out from `feature/upload_improvements`. If that branch is merged (#10), this PR has to be re-created*

- Change `uri` parameter to `path` when video name is clicked
  - Change flow in VideoPreview - we will now fetch the DB for
    information about this path (Also pushed backend to support this query param)
- Add generation of metadata

This means, if someone links a video, it should **no longer** look like this:

<img width="777" alt="image" src="https://user-images.githubusercontent.com/5310116/163459374-a7370794-c471-4c1f-afed-0ccf0e19f1b2.png">


But instead something like this:

<img width="535" alt="image" src="https://user-images.githubusercontent.com/5310116/163459433-1367153f-1a06-4b1d-8a74-6142a5d0d0eb.png">


- [ ] Add 404 not found